### PR TITLE
Make perturbopy compatible with pytest7.4

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include src/perturbopy *.cfg
+

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
    name='perturbopy',
    version='0.1.0',
    python_requires='>=3.7.12',
+   include_package_data=True,
    install_requires=[
       'numpy>=1.21.4',
       'pytest',

--- a/src/perturbopy/setup.cfg
+++ b/src/perturbopy/setup.cfg
@@ -1,0 +1,1 @@
+[tool:pytest]


### PR DESCRIPTION
Hello everyone, 
Recently `pytest` released an update that has been a pain for many packages. Now in order to run tests with config files, you have to explicitly specify `rootdir` with additional files. This is done in the current PR. 