### PR TITLE
Delete devel option, fix problems with tags and remove unneсessary test folders printing

### DIFF
--- a/src/perturbopy/conftest.py
+++ b/src/perturbopy/conftest.py
@@ -49,10 +49,6 @@ def pytest_addoption(parser):
                      help='List of test names to include in this testsuite run.',
                      nargs='*', default=None)
 
-    parser.addoption('--devel',
-                     help='Include the development-stage tests.',
-                     action='store_true', default=False)
-
     parser.addoption('--run_qe2pert',
                      help='Include the qe2pert tests',
                      action='store_true')
@@ -105,10 +101,6 @@ def pytest_generate_tests(metafunc):
 
         # Get the list of all test folders
         all_test_list, all_dev_test_list = get_all_tests(metafunc.function.__name__, source_folder)
-
-        # Add the devel tests if --devel was specified
-        if metafunc.config.getoption('devel'):
-            all_test_list += all_dev_test_list
 
         if (metafunc.function.__name__ == 'test_perturbo') or (metafunc.function.__name__ == 'test_perturbo_for_qe2pert'):
             # sort out test folders based on command-line options (if present)

--- a/src/perturbopy/test_utils/run_test/run_utils.py
+++ b/src/perturbopy/test_utils/run_test/run_utils.py
@@ -199,7 +199,7 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
             if tags is not None:
 
                 keep_test = False
-                l=0
+
                 for tag in tags:
                     if tag in test_tag_list:
                         keep_test = True
@@ -253,10 +253,10 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
 
         test_list = test_names
 
-    if not test_list and not ((func_name=='test_perturbo_for_qe2pert') and not (run_qe2pert)):
+    if not test_list and not ((func_name == 'test_perturbo_for_qe2pert') and not (run_qe2pert)):
         raise RuntimeError('No test folders selected')
     
-    if (func_name=='test_perturbo'):
+    if (func_name == 'test_perturbo'):
         print('\n\n === Test folders == :')
     print(' \n'.join(test_list))
     print('')

--- a/src/perturbopy/test_utils/run_test/run_utils.py
+++ b/src/perturbopy/test_utils/run_test/run_utils.py
@@ -12,7 +12,7 @@ from perturbopy.io_utils.io import open_yaml
 def read_test_tags(test_name, func_name, source_folder):
     """
     Get a list of tags for a given test. List of tags is combined from the tags from
-    pert_input.yml and epr_info.yml for a given epr file.
+    pert_input.yml and test_listing.yml for a given epr file.
 
     Parameters
     ----------
@@ -32,7 +32,7 @@ def read_test_tags(test_name, func_name, source_folder):
         name of the epr file associated with this test
     """
     
-    epr_dict_path = os.path.join(source_folder, 'epr_info.yml')
+    epr_dict_path = os.path.join(source_folder, 'test_listing.yml')
     epr_info = open_yaml(epr_dict_path)
 
     if (func_name == 'test_perturbo') or (func_name == 'test_perturbo_for_qe2pert'):
@@ -45,7 +45,7 @@ def read_test_tags(test_name, func_name, source_folder):
         if 'tags' in pert_input['test info'].keys():
             input_tags = pert_input['test info']['tags']
 
-        # Read the tags from epr_info.yml
+        # Read the tags from test_listing.yml
         epr_name = pert_input['test info']['epr']
 
         epr_tags = []
@@ -65,7 +65,7 @@ def read_test_tags(test_name, func_name, source_folder):
 
 def get_all_tests(func_name, source_folder):
     """
-    Get the names of all test folders based on the epr_info.yml file.
+    Get the names of all test folders based on the test_listing.yml file.
 
     Parameters
     ----------
@@ -82,7 +82,7 @@ def get_all_tests(func_name, source_folder):
     test_folder_list = []
     dev_test_folder_list = []
 
-    epr_dict_path = os.path.join(source_folder, 'epr_info.yml')
+    epr_dict_path = os.path.join(source_folder, 'test_listing.yml')
     epr_info = open_yaml(epr_dict_path)
 
     if (func_name == 'test_perturbo') or (func_name == 'test_perturbo_for_qe2pert'):
@@ -199,7 +199,7 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
             if tags is not None:
 
                 keep_test = False
-
+                l=0
                 for tag in tags:
                     if tag in test_tag_list:
                         keep_test = True
@@ -240,7 +240,7 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
         for test_name_cmd in test_names:
             if test_name_cmd not in all_test_list:
                 if (func_name == 'test_perturbo') or (func_name == 'test_qe2pert'):
-                    errmsg = (f'Test {test_name_cmd} is not listed in epr_info.yml, \n'
+                    errmsg = (f'Test {test_name_cmd} is not listed in test_listing.yml, \n'
                               f'but specified in --test-names option. Full test_list: {test_list}'
                              )
                     raise ValueError(errmsg)
@@ -253,10 +253,11 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
 
         test_list = test_names
 
-    if not test_list:
+    if not test_list and not ((func_name=='test_perturbo_for_qe2pert') and not (run_qe2pert)):
         raise RuntimeError('No test folders selected')
-
-    print('\n\n === Test folders == :')
+    
+    if (func_name=='test_perturbo'):
+        print('\n\n === Test folders == :')
     print(' \n'.join(test_list))
     print('')
     sys.stdout.flush()


### PR DESCRIPTION
Hello everyone, 
In this PR we are solving a problem with tags - previously, if certain tags were selected, a "no test folders" error would occur. The error was due to the fact that these same tags were tested at the `test_perturbo_for_qe2pert` stage, where the number of tests is less, and there really could be no tests with such tags. At the same time, `tests for test_perturbo_for_qe2pert` test selection are runned in any case - whether we run this test or not (this is how `config.py` works).
Now the problem is solved with 1 additional if.
Also, we removed the devel option and also removed the unnecessary printing of the line `=== Test folders == :`
Finally, we've renamed `epr_info.yaml` file to the `test_listing.yml` file.
