### PR TITLE
Add producing of error files in case of the fail of some comparisons

### DIFF
--- a/src/perturbopy/test_utils/compare_data/compare.py
+++ b/src/perturbopy/test_utils/compare_data/compare.py
@@ -51,6 +51,7 @@ def equal_values(file1, file2, ig_n_tol):
         raise ValueError(errmsg)
 
     if not equal_values:
+        
         print(f' difference: {diff}')
 
     return equal_values

--- a/src/perturbopy/test_utils/compare_data/h5.py
+++ b/src/perturbopy/test_utils/compare_data/h5.py
@@ -14,18 +14,22 @@ def equal_scalar(scalar1, scalar2, key, ig_n_tol):
     Parameters
     ----------
     scalar1 : numpy.dtype
-       first  scalar
+        first  scalar
     scalar2 : numpy.dtype
-       second scalar
+        second scalar
     key : str
-       key associated with this scalar
+        key associated with this scalar
     ig_n_tol : dict
-       dictionary of ignore keywords and tolerances needed to make comparison on values
+        dictionary of ignore keywords and tolerances needed to make comparison on values
 
     Returns
     -------
     equal_value : bool
-       boolean specifying if both scalars contain the same values
+        boolean specifying if both scalars contain the same values
+    diff_str : str
+        string which contains the information about the calculation error
+    output_res_val : str
+        here for consistency, just a copy of the diff_str
 
     """
     # check that scalar1 and scalar2 are Numbers
@@ -51,8 +55,23 @@ def equal_scalar(scalar1, scalar2, key, ig_n_tol):
 
     else:
         diff_str = f'{diff:.1e}'
+        
+    output_res_val = diff_str
 
-    return equal_value, diff_str
+    return equal_value, diff_str, output_res_val
+    
+    
+def format_string(val1, val2):
+    """
+    Supplementary function for the equal_ndarray function.
+    Return the string in the desired format.
+
+    """
+    try:
+        rel_diff = abs(val2 - val1) / val2
+    except ZeroDivisionError:
+        rel_diff = float('inf')
+    return f"value here: {val1:.2e}, reference:({val2:.2e}), abs_diff={abs(val2-val1):.2e}, rel_diff={rel_diff:.2e}"
 
 
 def equal_ndarray(ndarray1, ndarray2, key, ig_n_tol):
@@ -75,6 +94,13 @@ def equal_ndarray(ndarray1, ndarray2, key, ig_n_tol):
     -------
     equal_vlaues : bool
        boolean specifying if both ndarrays are equivalent
+    diff : str
+        string which contains the information about biggest
+        difference between produced file and reference
+    output_arr : ndarray
+        numpy array with the original data from the produced files.
+        Where the error was found, value is changed by the line:
+        value here: {val1}, reference:({val2}), abs_diff={abs(val2-val1)}, rel_diff={abs(val2-val1)/val2}
 
     """
     errmsg = ('ndarray1/2 are not ndarrays')
@@ -109,11 +135,25 @@ def equal_ndarray(ndarray1, ndarray2, key, ig_n_tol):
         rdiff = np.abs((v2 - v1) / v1)
         diff_str = (f'{diff:.1e}, {rdiff*100:.1e}%, v1={v1:.1e}, v2={v2:.1e},'
                     f'atol={atol:.1e}, rtol={rtol:.1e},')
+        where_error = np.isclose(ndarray1,
+                                      ndarray2,
+                                      atol=atol,
+                                      rtol=rtol,
+                                      equal_nan=True)
 
     else:
         diff_str = f'{diff:.1e}'
+        
+    where_error = ~np.isclose(ndarray1,
+                              ndarray2,
+                              atol=atol,
+                              rtol=rtol,
+                              equal_nan=True)
+                              
+    vectorized_format = np.vectorize(format_string)
+    output_arr = np.where(where_error, vectorized_format(ndarray2, ndarray1), ndarray2.astype(str))
 
-    return equal_value, diff_str
+    return equal_value, diff_str, output_arr
 
 
 def equal_dict(dict1, dict2, ig_n_tol, path):
@@ -123,25 +163,32 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
 
     .. note::
 
-       Dict structure is assumed to be composed of
-       other dictionaries, numpy.ndarray, numpy.int32 and
-       numpy.float64
+        Dict structure is assumed to be composed of
+        other dictionaries, numpy.ndarray, numpy.int32 and
+        numpy.float64
 
     Parameters
     ----------
     dict1 : dict
-       first  dictionary
+        first  dictionary
     dict2 : dict
-       second dictionary
+        second dictionary
     ig_n_tol : dict
-       dictionary of ignore keywords and tolerances needed to make comparison on values
+        dictionary of ignore keywords and tolerances needed to make comparison on values
     path : str
-       pseudo path to this item being compared
+        pseudo path to this item being compared
 
     Returns
     -------
     equal_values : bool
-       boolean specifying if both dicts contain the same keys and values
+        boolean specifying if both dicts contain the same keys and values
+    diff : str
+        string which contains the information about the number of
+        failed tests
+    output_res_dict : dict
+        list with testing results. Either the item from the
+        produced yaml-file will be saved, or it will be saved
+        with the additional string FAIL
 
     """
 
@@ -164,7 +211,7 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
 
     # a list of bool values
     equal_per_key = []
-
+    output_res_dict = {}
     for key in keys:
         errmsg = (f'dict1/2 values associated with key:{key} '
                   f'are not of the same type')
@@ -173,13 +220,13 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
         # pseudo path to current item being compared
         key_path = (f'{path}.{key}')
         if isinstance(dict1[key], dict):
-            equal_value, diff = equal_dict(dict1[key], dict2[key], ig_n_tol, key_path)
+            equal_value, diff, output_res = equal_dict(dict1[key], dict2[key], ig_n_tol, key_path)
 
         elif isinstance(dict1[key], np.ndarray):
-            equal_value, diff = equal_ndarray(dict1[key], dict2[key], key, ig_n_tol)
+            equal_value, diff, output_res = equal_ndarray(dict1[key], dict2[key], key, ig_n_tol)
 
         elif (dict1[key].dtype == 'int32' or dict1[key].dtype == 'float64'):
-            equal_value, diff = equal_scalar(dict1[key], dict2[key], key, ig_n_tol)
+            equal_value, diff, output_res = equal_scalar(dict1[key], dict2[key], key, ig_n_tol)
 
         else:
             errmsg = (f'dict must only contain values of type dict, np.ndarray, np.int32,or np.float64 '
@@ -192,6 +239,9 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
         if not equal_value:
             print(f'\n !!! discrepancy found at {key_path}')
             print(f' difference: {diff}')
+            output_res_dict[key] = [output_res, "# !!!!FAIL!!!!"]
+        else:
+            output_res_dict[key] = [dict2[key]]
 
     # equal dicts produce list of only bool=True
     nitems = len(equal_per_key)
@@ -204,7 +254,7 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
     else:
         diff = f'among {nitems} elements, {nitems - ncompared} failed comparison'
 
-    return equal_values, diff
+    return equal_values, diff, output_res_dict
 
 
 def hdf5_to_dict(file_path):
@@ -239,6 +289,36 @@ def hdf5_to_dict(file_path):
     return hdf5_dict
 
 
+def save_dict_to_hdf5(group, dictionary):
+    """
+    Saved the dictionary into HDF5 file recursively.
+    Parameters
+    ----------
+    group : HDF5 file
+        file, where the dictionary will be saved
+    
+    dictionary: dict
+        dictionary with the information which will be saved
+
+    Returns
+    -------
+    None
+    .. note::
+        The initial passed group will be changed itself in-place
+    """
+    for key, value in dictionary.items():
+        if isinstance(value, dict):
+            # Если значение является словарем, создаем подгруппу и рекурсивно сохраняем туда данные
+            subgroup = group.create_group(key)
+            save_dict_to_hdf5(subgroup, value)
+        else:
+            if len(value) == 1:
+                group.create_dataset(key, data=value[0])
+            elif len(value) == 2:
+                dset = group.create_dataset(key, data=value[0].astype('S'), dtype=h5py.string_dtype(encoding='ascii'))
+                dset.attrs['attribute'] = value[1]
+
+
 def equal_values(file1, file2, ig_n_tol):
     """
     Checks if two h5 files contain the same hierarchy/groups/datasets
@@ -257,7 +337,13 @@ def equal_values(file1, file2, ig_n_tol):
     -------
     equal_values : bool
        boolean specifying if both h5 files contain the same information
+    diff : str
+        string which contains the information about the number of
+        failed tests
 
+    .. note::
+        Also, the file {name_of_file}_errors_file.h5 will be generated in case of the fail
+        of some comparisons.
     """
 
     h51_dict = hdf5_to_dict(file1)
@@ -275,5 +361,13 @@ def equal_values(file1, file2, ig_n_tol):
         errmsg = ('no entries left in dict after applying \'test keywords\'')
         assert len(h51_dict) > 0, errmsg
         assert len(h52_dict) > 0, errmsg
+        
+    equal_values, diff, output_res_dict = equal_dict(h51_dict, h52_dict, ig_n_tol, 'top of h5')
+    
+#    if not equal_values:
+    errors_file_name = f"{file2[:file2.find('.h5')]}_errors_file.h5"
+    with h5py.File(errors_file_name, 'w') as f:
+        print(errors_file_name)
+        save_dict_to_hdf5(f, output_res_dict)
 
-    return equal_dict(h51_dict, h52_dict, ig_n_tol, 'top of h5')
+    return equal_values, diff

--- a/src/perturbopy/test_utils/compare_data/yaml.py
+++ b/src/perturbopy/test_utils/compare_data/yaml.py
@@ -4,6 +4,7 @@ This module contains functions to compare YAML files
 """
 from numbers import Number
 import numpy as np
+import yaml
 import perturbopy.test_utils.compare_data.h5 as ch5
 from perturbopy.test_utils.run_test.run_utils import get_tol
 from perturbopy.io_utils.io import open_yaml
@@ -16,18 +17,22 @@ def equal_scalar(scalar1, scalar2, key, ig_n_tol):
     Parameters
     ----------
     scalar1 : numpy.dtype
-       first  scalar
+        first  scalar
     scalar2 : numpy.dtype
-       second scalar
+        second scalar
     key : str
-       key associated with this scalar
+        key associated with this scalar
     ig_n_tol : dict
-       dictionary of ignore keywords and tolerances needed to make comparison on values
+        dictionary of ignore keywords and tolerances needed to make comparison on values
 
     Returns
     -------
     equal_value : bool
-       boolean specifying if both scalars contain the same values
+        boolean specifying if both scalars contain the same values
+    diff_str : str
+        string which contains the information about the calculation error
+    output_res_val : str
+        here for consistency, just a copy of the diff_str
 
     """
     # check that scalar1 and scalar2 are Numbers
@@ -46,12 +51,14 @@ def equal_scalar(scalar1, scalar2, key, ig_n_tol):
 
     if np.abs(scalar1) > 1e-10:
         rdiff = np.abs((scalar2 - scalar1) / scalar1)
-        diff_str = f'{diff:.1e}, {rdiff*100:.1e}%, {scalar1 = }, {scalar2 = }'
+        diff_str = f'{diff:.1e}, {rdiff*100:.1e}%, computed={scalar1}, reference={scalar2}'
 
     else:
         diff_str = f'{diff:.1e}'
 
-    return equal_value, diff_str
+    output_res_val = f'{diff_str}'
+
+    return equal_value, diff_str, output_res_val
 
 
 def equal_list(list1, list2, key, ig_n_tol, path):
@@ -61,21 +68,28 @@ def equal_list(list1, list2, key, ig_n_tol, path):
     Parameters
     ----------
     list1 : list
-       first  list
+        first  list
     list2 : list
-       second list
+        second list
     key: str
-       A key for the tolerance. If this key is not specified in the tolerance dict,
-       a default tolerance will be applied
+        A key for the tolerance. If this key is not specified in the tolerance dict,
+        a default tolerance will be applied
     ig_n_tol : dict
-       dictionary of ignore keywords and tolerances needed to make comparison on values
+        dictionary of ignore keywords and tolerances needed to make comparison on values
     path : str
-       pseudo path to this item being compared
+        pseudo path to this item being compared
 
     Returns
     -------
     equal_vlaues : bool
-       boolean specifying if both lists are equivalent
+        boolean specifying if both lists are equivalent
+    diff : str
+        string which contains the information about the number of
+        failed tests
+    output_res_list : list
+        list with testing results. Either the item from the
+        produced yaml-file will be saved, or it will be saved
+        with the additional string FAIL
 
     """
     # check that list1 and list2 are lists
@@ -86,18 +100,10 @@ def equal_list(list1, list2, key, ig_n_tol, path):
     assert len(list1) == len(list2), errmsg
     indices = range(len(list1))
 
-    # check if lists can be converted to ndarray
-    if (all(isinstance(x, Number) for x in list1) and all(isinstance(x, Number) for x in list2)):
-
-        # compare lists as nparrays for speed up
-        return ch5.equal_ndarray(np.array(list1),
-                                 np.array(list2),
-                                 key,
-                                 ig_n_tol)
-
     # a list of bool values
     equal_per_item = []
 
+    output_res_list = []
     for item1, item2, index in zip(list1, list2, indices):
         errmsg = ('list1/2 values'
                   'are not of the same type')
@@ -106,13 +112,13 @@ def equal_list(list1, list2, key, ig_n_tol, path):
         # pseudo path to current item being compared
         item_path = (f'{path}.list[{index}]')
         if isinstance(item1, dict):
-            equal_value, diff = equal_dict(item1, item2, ig_n_tol, item_path)
+            equal_value, diff, output_res = equal_dict(item1, item2, ig_n_tol, item_path)
 
         elif isinstance(item1, list):
-            equal_value, diff = equal_list(item1, item2, key, ig_n_tol, item_path)
+            equal_value, diff, output_res = equal_list(item1, item2, key, ig_n_tol, item_path)
 
         elif isinstance(item1, Number):
-            equal_value, diff = equal_scalar(item1, item2, key, ig_n_tol)
+            equal_value, diff, output_res = equal_scalar(item1, item2, key, ig_n_tol)
 
         elif isinstance(item1, str):
             equal_value = item1 == item2
@@ -131,6 +137,9 @@ def equal_list(list1, list2, key, ig_n_tol, path):
         if not equal_value:
             print(f'\n !!! discrepancy found at {item_path}')
             print(f' difference: {diff}')
+            output_res_list.append(['!!!!FAIL!!!!', output_res])
+        else:
+            output_res_list.append(f'{item2}')
 
     # equal dicts produce list of only bool=True
     nitems = len(equal_per_item)
@@ -143,8 +152,8 @@ def equal_list(list1, list2, key, ig_n_tol, path):
     else:
         diff = f'among {nitems} elements, {nitems - ncompared} failed comparison'
 
-    return equal_values, diff
-
+    return equal_values, diff, output_res_list
+    
 
 def equal_dict(dict1, dict2, ig_n_tol, path):
     """
@@ -154,18 +163,25 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
     Parameters
     ----------
     dict1 : dict
-       first  dictionary
+        first  dictionary
     dict2 : dict
-       second dictionary
+        second dictionary
     ig_n_tol : dict
-       dictionary of ignore keywords and tolerances needed to make comparison on values
+        dictionary of ignore keywords and tolerances needed to make comparison on values
     path : str
-       pseudo path to this item being compared
+        pseudo path to this item being compared
 
     Returns
     -------
     equal_vlaues : bool
-       boolean specifying if both dicts contain the same keys and values
+        boolean specifying if both dicts contain the same keys and values
+    diff : str
+        string which contains the information about the number of
+        failed tests
+    output_res_dict : dict
+        list with testing results. Either the item from the
+        produced yaml-file will be saved, or it will be saved
+        with the additional string FAIL
 
     """
     # check that dict1 and dict2 are dictionaries
@@ -187,7 +203,7 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
 
     # a list of bool values
     equal_per_key = []
-
+    output_res_dict = {}
     for key in keys:
         errmsg = (f'dict1/2 values associated with key:{key} '
                   f'are not of the same type')
@@ -196,13 +212,13 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
         # pseudo path to current item being compared
         key_path = (f'{path}.{key}')
         if isinstance(dict1[key], dict):
-            equal_value, diff = equal_dict(dict1[key], dict2[key], ig_n_tol, key_path)
+            equal_value, diff, output_res = equal_dict(dict1[key], dict2[key], ig_n_tol, key_path)
 
         elif isinstance(dict1[key], list):
-            equal_value, diff = equal_list(dict1[key], dict2[key], key, ig_n_tol, key_path)
+            equal_value, diff, output_res = equal_list(dict1[key], dict2[key], key, ig_n_tol, key_path)
 
         elif isinstance(dict1[key], Number):
-            equal_value, diff = equal_scalar(dict1[key], dict2[key], key, ig_n_tol)
+            equal_value, diff, output_res = equal_scalar(dict1[key], dict2[key], key, ig_n_tol)
 
         elif isinstance(dict1[key], str):
             equal_value = dict1[key] == dict2[key]
@@ -222,6 +238,9 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
         if not equal_value:
             print(f'\n !!! discrepancy found at {key_path}')
             print(f' difference: {diff}')
+            output_res_dict[key] = ["# !!!!FAIL!!!!", output_res]
+        else:
+            output_res_dict[key] = [dict2[key]]
 
     # equal dicts produce list of only bool=True
     nitems = len(equal_per_key)
@@ -234,7 +253,7 @@ def equal_dict(dict1, dict2, ig_n_tol, path):
     else:
         diff = f'among {nitems} elements, {nitems - ncompared} failed comparison'
 
-    return equal_values, diff
+    return equal_values, diff, output_res_dict
 
 
 def equal_values(file1, file2, ig_n_tol):
@@ -245,16 +264,23 @@ def equal_values(file1, file2, ig_n_tol):
     Parameters
     ----------
     file1 : str
-       first  YAML file name
+        first  YAML file name
     file2 : str
-       second YAML file name
+        second YAML file name
     ig_n_tol : dict
-       dictionary of keywords and tolerances needed to make comparison on files
+        dictionary of keywords and tolerances needed to make comparison on files
 
     Returns
     -------
     equal_vlaues : bool
-       boolean specifying if both YAML files contain the same keys and values
+        boolean specifying if both YAML files contain the same keys and values
+    diff : str
+        string which contains the information about the number of
+        failed tests
+    
+    .. note::
+        Also, the file {name_of_file}_errors_file.yml will be generated in case of the fail
+        of some comparisons.
 
     """
     yaml1_dict = open_yaml(file1)
@@ -273,4 +299,12 @@ def equal_values(file1, file2, ig_n_tol):
         assert len(yaml1_dict) > 0, errmsg
         assert len(yaml2_dict) > 0, errmsg
 
-    return equal_dict(yaml1_dict, yaml2_dict, ig_n_tol, 'top of yaml')
+    equal_values, diff, output_res_dict = equal_dict(yaml1_dict, yaml2_dict, ig_n_tol, 'top of yaml')
+
+    if not equal_values:
+        file_name = f"{file2[:file2.find('.yml')]}_errors_file.yml"
+
+        with open(file_name, 'w', encoding='utf-8') as yaml_file:
+            yaml.dump(output_res_dict, yaml_file, allow_unicode=True)
+
+    return equal_values, diff


### PR DESCRIPTION
Hello everyone, 

In this PR we greatly simplify the work with errors received during testing. Now in case of failure of any comparisons between the produced and reference values, a new file `{file-name}_errors_file.h5` or `{file-name}_errors_file.yaml` will be created. This file will explicitly state exactly where the error occurred and designate specific reference values and the size of the error. 
For example, in case of a comparison error in the `epr3-bands` test, we will get a new file `graphene_bands_errors_file.yml` with this content:
```
bands:
- '# !!!!FAIL!!!!'
- band index:
  - '# !!!!FAIL!!!!'
  - 1:
    - '# !!!!FAIL!!!!'
    - - - '!!!!FAIL!!!!'
        - 1.4e+01, 2.0e+02%, computed=7.215438877, reference=-7.215438877
      - '-9.0928148696'
      - '-9.1636226969'
      - '-8.1497525861'
...next lines...
```

In case of the hdf5 file, the datasets for which the comparison returned an error will have the attribute `FAIL`, also within the dataset itself will be the calculation errors, the obtained value and the reference value, roughly like this:
```
value here: 4.48e-01, reference:(1.00e-10), abs_diff=4.48e-01, rel_diff=4.48e+09
```
Partly, this solves the problem identified in Issue #34 - we will now have a set of files in which calculation errors are explicitly labeled. 
Any suggestions and recommendations are welcome!