### PR TITLE
Eliminate warning from division by zero

### DIFF
--- a/src/perturbopy/test_utils/compare_data/h5.py
+++ b/src/perturbopy/test_utils/compare_data/h5.py
@@ -67,7 +67,7 @@ def format_string(val1, val2):
     Return the string in the desired format.
 
     """
-    if abs(val2)<1e-20:
+    if abs(val2) < 1e-20:
         rel_diff = float('inf')
     else:
         rel_diff = abs(val2 - val1) / val2

--- a/src/perturbopy/test_utils/compare_data/h5.py
+++ b/src/perturbopy/test_utils/compare_data/h5.py
@@ -67,10 +67,11 @@ def format_string(val1, val2):
     Return the string in the desired format.
 
     """
-    try:
-        rel_diff = abs(val2 - val1) / val2
-    except ZeroDivisionError:
+    if abs(val2)<1e-20:
         rel_diff = float('inf')
+    else:
+        rel_diff = abs(val2 - val1) / val2
+
     return f"value here: {val1:.2e}, reference:({val2:.2e}), abs_diff={abs(val2-val1):.2e}, rel_diff={rel_diff:.2e}"
 
 


### PR DESCRIPTION
In this PR, we eliminate a possible warning caused by division by zero. Previously, we only handled the `ZeroDivisionError` error, but when we vectorize the function, `numpy` returns Warning instead of this error, so this case was not handled at all. Now we have set up a rather simple if, which checks the value of the number we plan to divide by. If it is less than `1e-20`, we just return `inf`.
Thanks to @pinkston3 for catching this problem!