### PR TITLE
Fix issue with the virtual environment

### DIFF
--- a/src/perturbopy/tests_use.py
+++ b/src/perturbopy/tests_use.py
@@ -5,7 +5,6 @@ from perturbopy import testing_code
 
 def do_tests(testing_args):
     dir_path = os.path.dirname(testing_code.__file__)
-    print(dir_path)
     testing_args.insert(0, dir_path)
     result = pytest.main(testing_args)
     return result

--- a/src/perturbopy/tests_use.py
+++ b/src/perturbopy/tests_use.py
@@ -1,8 +1,11 @@
 import pytest
+import os
 from perturbopy import testing_code
 
 
 def do_tests(testing_args):
-    testing_args.insert(0, testing_code.__file__)
+    dir_path = os.path.dirname(testing_code.__file__)
+    print(dir_path)
+    testing_args.insert(0, dir_path)
     result = pytest.main(testing_args)
     return result


### PR DESCRIPTION
Hey, everybody!
Thanks to @pinkston3  and @alex2shiyu , it was discovered that the current version of perturbopy does not work when running tests using the `conda` virtual environment. The problem was that the previous version of `test_use.py` used the `__init__.py` file address rather than the containing folder (which is more correct). The `__init__.py` path works if you don't use the virtual environment, it also previously worked with the `conda` virtual environment. My assumption is that the conda developers changed something in the latest versions. 
Anyway, this PR changes the address used to a folder address, which allows you to use perturbopy tests in a virtual environment. 