### PR TITLE
Changing the pipeline for qe2pert tests: downloading required files instead of QE calculations. 

### DIFF
--- a/src/perturbopy/conftest.py
+++ b/src/perturbopy/conftest.py
@@ -12,6 +12,7 @@ In this file (conftest.py), we parametrize pytest to make this work.
 from perturbopy.test_utils.run_test.run_utils import get_all_tests
 from perturbopy.test_utils.run_test.run_utils import filter_tests
 from perturbopy.test_utils.run_test.test_driver import clean_epr_folders
+from perturbopy.test_utils.run_test.env_utils import load_files_from_box
 import pytest
 import os
 
@@ -115,6 +116,8 @@ def pytest_generate_tests(metafunc):
                 source_folder
             )
         elif (metafunc.function.__name__ == 'test_qe2pert'):
+            # download the necessary files from remote storage
+            load_files_from_box(source_folder, metafunc.config.getoption('config_machine'))
             test_list = filter_tests(
                 all_test_list,
                 metafunc.config.getoption('epr_tags'),

--- a/src/perturbopy/test_utils/run_test/env_utils.py
+++ b/src/perturbopy/test_utils/run_test/env_utils.py
@@ -39,10 +39,11 @@ def run_from_config_machine(config_machine, step):
 
     return run
     
+
 def move_qe2pert_files(source_folder, work_path, epr_name, config_machine):
     """
-    Moves the auxiliary files for qe2pert tests from a previously downloaded 
-    and unzipped archive to the folder where all tests are run. 
+    Moves the auxiliary files for qe2pert tests from a previously downloaded
+    and unzipped archive to the folder where all tests are run.
     
     Parameters
     ----------
@@ -78,14 +79,14 @@ def move_qe2pert_files(source_folder, work_path, epr_name, config_machine):
         
         # Create the corresponding subdirectory in the destination folder
         dst_subfolder = os.path.join(work_path, relative_path)
-        #dst_subfolder = work_path
+
         if not os.path.exists(dst_subfolder):
             os.makedirs(dst_subfolder)
 
         for file_name in files:
             src_file_path = os.path.join(root, file_name)
             dst_file_path = os.path.join(dst_subfolder, file_name)
-            shutil.copy2(src_file_path, dst_file_path) 
+            shutil.copy2(src_file_path, dst_file_path)
     
 
 def copy_folder_with_softlinks(src, dst, perturbo_scratch_dir_prefix=None, test_name=None, second_run=False):
@@ -244,11 +245,12 @@ def softlink_epr_files(perturbo_scratch_dir_prefix, test_name, dst, file_name):
         os.symlink(src, dst)
     except FileNotFoundError:
         raise FileNotFoundError(f"Ephr-file for {test_name} wasn't found or calculated")
-        
+
+
 def load_files_from_box(source_folder, config_machine):
     """
-    Downloads files needed for qe2pert tests from remote cloud storage. 
-    Runs once during test initialization. 
+    Downloads files needed for qe2pert tests from remote cloud storage.
+    Runs once during test initialization.
 
     Parameters
     ----------

--- a/src/perturbopy/test_utils/run_test/env_utils.py
+++ b/src/perturbopy/test_utils/run_test/env_utils.py
@@ -3,9 +3,8 @@
 """
 import os
 import shutil
-import re
-import requests
-
+import subprocess
+from perturbopy.io_utils.io import open_yaml
 
 
 def run_from_config_machine(config_machine, step):
@@ -39,6 +38,54 @@ def run_from_config_machine(config_machine, step):
         raise AttributeError(errmsg)
 
     return run
+    
+def move_qe2pert_files(source_folder, work_path, epr_name, config_machine):
+    """
+    Moves the auxiliary files for qe2pert tests from a previously downloaded 
+    and unzipped archive to the folder where all tests are run. 
+    
+    Parameters
+    ----------
+    source_folder : str
+        path of source directory. Inside of this folder we need to have additional temporary
+        folder for calculations ('PERT_SCRATCH')
+    
+    work_path : str
+        working directory to which the function moves the files
+    
+    epr_name : str
+        name of epr-file calculation, for which files are moved
+    
+    config_machine : dict
+        dictionary with executional commands for the test steps
+
+    Returns
+    -------
+    None
+
+    """
+
+    try:
+        source_folder = os.path.join(source_folder, config_machine['PERT_SCRATCH'])
+    except KeyError:
+        source_folder   = os.path.join(source_folder, "PERT_SCRATCH")
+    src = f'{source_folder}/tests_qe2pert/{epr_name}'
+    # Get the list of files in the source folder
+    for root, dirs, files in os.walk(src):
+        
+        # Determine the relative path of the current directory
+        relative_path = os.path.relpath(root, src)
+        
+        # Create the corresponding subdirectory in the destination folder
+        dst_subfolder = os.path.join(work_path, relative_path)
+        #dst_subfolder = work_path
+        if not os.path.exists(dst_subfolder):
+            os.makedirs(dst_subfolder)
+
+        for file_name in files:
+            src_file_path = os.path.join(root, file_name)
+            dst_file_path = os.path.join(dst_subfolder, file_name)
+            shutil.copy2(src_file_path, dst_file_path) 
     
 
 def copy_folder_with_softlinks(src, dst, perturbo_scratch_dir_prefix=None, test_name=None, second_run=False):
@@ -198,42 +245,39 @@ def softlink_epr_files(perturbo_scratch_dir_prefix, test_name, dst, file_name):
     except FileNotFoundError:
         raise FileNotFoundError(f"Ephr-file for {test_name} wasn't found or calculated")
         
-def download_files_from_url(url, path):
-    # uploas the content of the page
-    response = requests.get(url)
-    html_content = response.text
+def load_files_from_box(source_folder, config_machine):
+    """
+    Downloads files needed for qe2pert tests from remote cloud storage. 
+    Runs once during test initialization. 
 
-    # looking for the files and folders
-    file_links = re.findall(r'href="(https://[^\s"]+\.(?:pdf|zip|jpg|png|docx))"', html_content)
-    folder_links = re.findall(r'href="(https://[^\s"]+/s/[^\s"]+)"', html_content)
+    Parameters
+    ----------
+    source_folder : str
+        path of source directory
+    
+    config_machine : str
+        name of config_machine file for this tests
 
-    # load files
-    for file_url in file_links:
-        file_name = file_url.split('/')[-1]
-        file_path = os.path.join(path, file_name)
+    Raises
+    ------
+    ValueError
+       if corresponding epr-file wasn't found or calculated.
 
-        print(f'Load {file_name}...')
-        file_response = requests.get(file_url)
-        with open(file_path, 'wb') as file:
-            file.write(file_response.content)
+    Returns
+    -------
+    None
 
-        print(f'{file_name} downloaded in {file_path}')
-
-    # Recursive process for the subfolders
-    for folder_url in folder_links:
-        # take the folder name from the url
-        folder_name = folder_url.split('/')[-1]
-        new_path = os.path.join(path, folder_name)
-
-        # make corresponding folder
-        if not os.path.exists(new_path):
-            os.makedirs(new_path)
-
-        print(f'Go to the folder: {folder_name}')
-        download_files_from_url(folder_url, new_path)
-        
-def load_files_from_box(link, save_folder):
+    """
+    config_machine = open_yaml(os.path.join(source_folder, f'config_machine/{config_machine}'))
+    try:
+        save_folder = os.path.join(source_folder, config_machine['PERT_SCRATCH'])
+    except KeyError:
+        save_folder   = os.path.join(source_folder, "PERT_SCRATCH")
     if not os.path.exists(save_folder):
         os.makedirs(save_folder)
-    download_files_from_url(link, save_folder)
+    # just download and unpack zip-archive. Ommit download if we already have this folder
+    if not os.path.exists(f'{save_folder}/tests_qe2pert'):
+        subprocess.run(f'wget {config_machine["source_link"]} -P {save_folder}', shell=True)
+        subprocess.run(['unzip', f'{save_folder}/{config_machine["source_link"].split("/")[-1]}', '-d', f'{save_folder}'])
+    
     

--- a/src/perturbopy/test_utils/run_test/test_driver.py
+++ b/src/perturbopy/test_utils/run_test/test_driver.py
@@ -83,7 +83,7 @@ def preliminary_commands(config_machine, step):
     return list_of_coms
     
 
-# Legacy code, it may be possible to use it again in the future, so don't delete it yet. 
+# Legacy code, it may be possible to use it again in the future, so don't delete it yet.
 # def run_scf(source_folder, work_path, config_machine, input_name='scf.in', output_name='scf.out'):
 #     """
 #     Function for scf calculation
@@ -494,7 +494,6 @@ def run_epr_calculation(epr_name, config_machine, source_folder):
 
     # move supplementary files for this calculation
     move_qe2pert_files(source_folder, work_path, epr_name, config_machine)
-    
 
     # run qe2pert
     run_qe2pert(source_folder, work_path, config_machine, prefix)

--- a/src/perturbopy/test_utils/run_test/test_driver.py
+++ b/src/perturbopy/test_utils/run_test/test_driver.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from perturbopy.io_utils.io import open_yaml
 from perturbopy.test_utils.run_test.env_utils import run_from_config_machine
-from perturbopy.test_utils.run_test.env_utils import perturbo_scratch_dir_config
+from perturbopy.test_utils.run_test.env_utils import perturbo_scratch_dir_config, load_files_from_box
 from perturbopy.test_utils.run_test.run_utils import print_test_info, setup_default_tol
 from perturbopy.test_utils.run_test.run_utils import ph_collection, define_nq_num
 
@@ -398,15 +398,66 @@ def get_test_materials(test_name, test_case, config_machine, source_folder):
             igns_n_tols)
 
 
+# def run_epr_calculation(epr_name, config_machine, source_folder):
+#     """
+#     Run one test:
+#         #. Run scf calculation
+#         #. Run phonon calculation
+#         #. Run nscf calculation
+#         #. Run wannier90 calculation
+#         #. Run qe2pert calculation
+#
+#     Parameters
+#     ----------
+#     epr_name : str
+#         name of computed epr_name file
+#     config_machine : str
+#         name of file with computational information, which we'll use in this set of computations.
+#         Should be in folder {source_folder}/config_machine.
+#     source_folder : str
+#         name of the folder, where should be all the testing supplementary files (reference, input files, etc.)
+#
+#     Returns
+#     -----
+#     None
+#     """
+#     # suffixes of paths needed to find driver/utils/references
+#     inputs_path_suffix = f'epr_computation/{epr_name}'
+#     config_machine = open_yaml(os.path.join(source_folder, f'config_machine/{config_machine}'))
+#
+#     # determine needed paths
+#     inputs_dir_path = os.path.join(source_folder, inputs_path_suffix)
+#     work_path = perturbo_scratch_dir_config(source_folder, inputs_dir_path, epr_name, config_machine, test_case='epr_calculation')
+#
+#     # open input yaml-files with supplementary info
+#     # and computational commands
+#     input_yaml = open_yaml(os.path.join(source_folder, 'test_listing.yml'))
+#
+#     # print the test information before the run
+#     print_test_info(epr_name, input_yaml, test_type='qe2pert')
+#
+#     # define the prefix - we'll need to have it in the later computations
+#     prefix = input_yaml[epr_name]['prefix']
+#
+#     # run scf
+#     run_scf(source_folder, work_path, config_machine)
+#
+#     # run phonon
+#     run_phonon(source_folder, work_path, config_machine, prefix)
+#
+#     # run nscf
+#     run_nscf(source_folder, work_path, config_machine)
+#
+#     # run wannier90
+#     run_wannier(source_folder, work_path, config_machine, prefix)
+#
+#     # run qe2pert
+#     run_qe2pert(source_folder, work_path, config_machine, prefix)
+#
+#     return
+
 def run_epr_calculation(epr_name, config_machine, source_folder):
     """
-    Run one test:
-        #. Run scf calculation
-        #. Run phonon calculation
-        #. Run nscf calculation
-        #. Run wannier90 calculation
-        #. Run qe2pert calculation
-
     Parameters
     ----------
     epr_name : str
@@ -428,29 +479,20 @@ def run_epr_calculation(epr_name, config_machine, source_folder):
     # determine needed paths
     inputs_dir_path = os.path.join(source_folder, inputs_path_suffix)
     work_path = perturbo_scratch_dir_config(source_folder, inputs_dir_path, epr_name, config_machine, test_case='epr_calculation')
-    
+
     # open input yaml-files with supplementary info
     # and computational commands
     input_yaml = open_yaml(os.path.join(source_folder, 'test_listing.yml'))
 
     # print the test information before the run
     print_test_info(epr_name, input_yaml, test_type='qe2pert')
-    
+
     # define the prefix - we'll need to have it in the later computations
     prefix = input_yaml[epr_name]['prefix']
 
     # run scf
-    run_scf(source_folder, work_path, config_machine)
-    
-    # run phonon
-    run_phonon(source_folder, work_path, config_machine, prefix)
+    load_files_from_box(f'{config_machine["source_link"]}/{epr_name}',work_path)
 
-    # run nscf
-    run_nscf(source_folder, work_path, config_machine)
-    
-    # run wannier90
-    run_wannier(source_folder, work_path, config_machine, prefix)
-    
     # run qe2pert
     run_qe2pert(source_folder, work_path, config_machine, prefix)
 

--- a/src/perturbopy/test_utils/run_test/test_driver.py
+++ b/src/perturbopy/test_utils/run_test/test_driver.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from perturbopy.io_utils.io import open_yaml
 from perturbopy.test_utils.run_test.env_utils import run_from_config_machine
-from perturbopy.test_utils.run_test.env_utils import perturbo_scratch_dir_config, load_files_from_box
+from perturbopy.test_utils.run_test.env_utils import perturbo_scratch_dir_config, move_qe2pert_files
 from perturbopy.test_utils.run_test.run_utils import print_test_info, setup_default_tol
 from perturbopy.test_utils.run_test.run_utils import ph_collection, define_nq_num
 
@@ -83,191 +83,192 @@ def preliminary_commands(config_machine, step):
     return list_of_coms
     
 
-def run_scf(source_folder, work_path, config_machine, input_name='scf.in', output_name='scf.out'):
-    """
-    Function for scf calculation
-
-    Parameters
-    ----------
-    source_folder : str
-        path of source directory
-    work_path : str
-        path to dir with input file, where we'll run the calculations
-    config_machine : dict
-        dictionary, which include the commands for scf calculation
-    input_name : str, optional
-        name of the input file, default: 'scf.in'
-    output_name : str, optional
-        name of the output file, default: 'scf.out'
-
-    Returns
-    -------
-    None
-
-    """
-
-    command = run_from_config_machine(config_machine, 'scf')
-    run = f'{command} -i {input_name} | tee {output_name}'
-
-    os.chdir(f'{work_path}/pw-ph-wann/scf/')
-
-    print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
-
-    print(f' === Running scf === :\n {run}')
-    sys.stdout.flush()
-
-    subprocess.run(preliminary_commands(config_machine, 'scf') + run, shell=True)
-
-    os.chdir(source_folder)
-    
-
-def run_phonon(source_folder, work_path, config_machine, prefix, input_name='ph.in', output_name='ph.out'):
-    """
-    Function for nscf calculation
-
-    Parameters
-    ----------
-    source_folder : str
-        path of source directory
-    work_path : str
-        path to dir with input file, where we'll run the calculations
-    config_machine : dict
-        dictionary, which include the commands for phonon calculation
-    prefix : str
-        prefix which we use for the filenames
-    input_name : str, optional
-        name of the input file, default: 'ph.in'
-    output_name : str, optional
-        name of the output file, default: 'ph.out'
-
-    Returns
-    -------
-    None
-
-    """
-
-    command = run_from_config_machine(config_machine, 'phonon')
-    run = f'{command} -i {input_name} | tee {output_name}'
-
-    os.chdir(f'{work_path}/pw-ph-wann/phonon/')
-    softlink = '../scf/tmp'
-    print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
-    print(f'\n =Link tmp from scf= :\n {softlink}')
-    sys.stdout.flush()
-    os.symlink(softlink, 'tmp')
-
-    print(f' == Running Phonon = :\n {run}')
-    sys.stdout.flush()
-
-    subprocess.run(preliminary_commands(config_machine, 'phonon') + run, shell=True)
-    
-    nq_num = define_nq_num(output_name)
-    print(f' == Collect files == :\n ph_collection({prefix},{nq_num})')
-    sys.stdout.flush()
-    ph_collection(prefix, nq_num)
-    
-    os.chdir(source_folder)
-
-    
-def run_nscf(source_folder, work_path, config_machine, input_name='nscf.in', output_name='nscf.out'):
-    """
-    Function for nscf calculation
-
-    Parameters
-    ----------
-    source_folder : str
-        path of source directory
-    work_path : str
-        path to dir with input file, where we'll run the calculations
-    config_machine : dict
-        dictionary, which include the commands for nscf calculation
-    input_name : str, optional
-        name of the input file, default: 'nscf.in'
-    output_name : str, optional
-        name of the output file, default: 'nscf.out'
-
-    Returns
-    -------
-    None
-
-    """
-
-    command = run_from_config_machine(config_machine, 'nscf')
-    run = f'{command} -i {input_name} | tee {output_name}'
-
-    os.chdir(f'{work_path}/pw-ph-wann/nscf/')
-    softlink = '../scf/tmp'
-    print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
-    print(f'\n =Link tmp from scf= :\n {softlink}')
-    sys.stdout.flush()
-    os.symlink(softlink, 'tmp')
-
-    print(f' === Running nscf === :\n {run}')
-    sys.stdout.flush()
-
-    subprocess.run(preliminary_commands(config_machine, 'nscf') + run, shell=True)
-
-    os.chdir(source_folder)
-    
-
-def run_wannier(source_folder, work_path, config_machine, prefix, input_name='pw2wan.in', output_name='pw2wan.out'):
-    """
-    Function for wannier90 calculation
-
-    Parameters
-    ----------
-    source_folder : str
-        path of source directory
-    work_path : str
-        path to dir with input file, where we'll run the calculations
-    config_machine : dict
-        dictionary, which include the commands for wannier calculation
-    prefix : str
-        prefix which we use for the filenames
-    input_name : str, optional
-        name of the input file, default: 'pw2wan.in'
-    output_name : str, optional
-        name of the output file, default: 'pw2wan.out'
-
-    Returns
-    -------
-    None
-
-    """
-
-    command = run_from_config_machine(config_machine, 'wannier90')
-    run = f'{command} -pp {prefix}'
-    
-    # link the save-file from scf calculation
-    os.chdir(f'{work_path}/pw-ph-wann/wann/')
-    os.mkdir('tmp')
-    softlink = f'../../scf/tmp/{prefix}.save'
-    print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
-    print(f'\n =Link tmp from scf= :\n {softlink}')
-    sys.stdout.flush()
-    os.symlink(softlink, f'tmp/{prefix}.save')
-
-    # first run of wannier90
-    print(f' === Running pp === :\n {run}')
-    sys.stdout.flush()
-    subprocess.run(preliminary_commands(config_machine, 'wannier90') + run, shell=True)
-    
-    # run of pw2wan
-    command = run_from_config_machine(config_machine, 'pw2wannier90')
-    run = f'{command} -i {input_name} | tee {output_name}'
-    print(f' = Running pw2wan = :\n {run}')
-    sys.stdout.flush()
-    subprocess.run(preliminary_commands(config_machine, 'pw2wannier90') + run, shell=True)
-    
-    # second run of wannier90
-    command = run_from_config_machine(config_machine, 'wannier90')
-    run = f'{command} {prefix}'
-    print(f' = Running Wannier= :\n {run}')
-    sys.stdout.flush()
-    subprocess.run(preliminary_commands(config_machine, 'wannier90') + run, shell=True)
-    
-    os.chdir(source_folder)
-    
+# Legacy code, it may be possible to use it again in the future, so don't delete it yet. 
+# def run_scf(source_folder, work_path, config_machine, input_name='scf.in', output_name='scf.out'):
+#     """
+#     Function for scf calculation
+#
+#     Parameters
+#     ----------
+#     source_folder : str
+#         path of source directory
+#     work_path : str
+#         path to dir with input file, where we'll run the calculations
+#     config_machine : dict
+#         dictionary, which include the commands for scf calculation
+#     input_name : str, optional
+#         name of the input file, default: 'scf.in'
+#     output_name : str, optional
+#         name of the output file, default: 'scf.out'
+#
+#     Returns
+#     -------
+#     None
+#
+#     """
+#
+#     command = run_from_config_machine(config_machine, 'scf')
+#     run = f'{command} -i {input_name} | tee {output_name}'
+#
+#     os.chdir(f'{work_path}/pw-ph-wann/scf/')
+#
+#     print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
+#
+#     print(f' === Running scf === :\n {run}')
+#     sys.stdout.flush()
+#
+#     subprocess.run(preliminary_commands(config_machine, 'scf') + run, shell=True)
+#
+#     os.chdir(source_folder)
+#
+#
+# def run_phonon(source_folder, work_path, config_machine, prefix, input_name='ph.in', output_name='ph.out'):
+#     """
+#     Function for nscf calculation
+#
+#     Parameters
+#     ----------
+#     source_folder : str
+#         path of source directory
+#     work_path : str
+#         path to dir with input file, where we'll run the calculations
+#     config_machine : dict
+#         dictionary, which include the commands for phonon calculation
+#     prefix : str
+#         prefix which we use for the filenames
+#     input_name : str, optional
+#         name of the input file, default: 'ph.in'
+#     output_name : str, optional
+#         name of the output file, default: 'ph.out'
+#
+#     Returns
+#     -------
+#     None
+#
+#     """
+#
+#     command = run_from_config_machine(config_machine, 'phonon')
+#     run = f'{command} -i {input_name} | tee {output_name}'
+#
+#     os.chdir(f'{work_path}/pw-ph-wann/phonon/')
+#     softlink = '../scf/tmp'
+#     print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
+#     print(f'\n =Link tmp from scf= :\n {softlink}')
+#     sys.stdout.flush()
+#     os.symlink(softlink, 'tmp')
+#
+#     print(f' == Running Phonon = :\n {run}')
+#     sys.stdout.flush()
+#
+#     subprocess.run(preliminary_commands(config_machine, 'phonon') + run, shell=True)
+#
+#     nq_num = define_nq_num(output_name)
+#     print(f' == Collect files == :\n ph_collection({prefix},{nq_num})')
+#     sys.stdout.flush()
+#     ph_collection(prefix, nq_num)
+#
+#     os.chdir(source_folder)
+#
+#
+# def run_nscf(source_folder, work_path, config_machine, input_name='nscf.in', output_name='nscf.out'):
+#     """
+#     Function for nscf calculation
+#
+#     Parameters
+#     ----------
+#     source_folder : str
+#         path of source directory
+#     work_path : str
+#         path to dir with input file, where we'll run the calculations
+#     config_machine : dict
+#         dictionary, which include the commands for nscf calculation
+#     input_name : str, optional
+#         name of the input file, default: 'nscf.in'
+#     output_name : str, optional
+#         name of the output file, default: 'nscf.out'
+#
+#     Returns
+#     -------
+#     None
+#
+#     """
+#
+#     command = run_from_config_machine(config_machine, 'nscf')
+#     run = f'{command} -i {input_name} | tee {output_name}'
+#
+#     os.chdir(f'{work_path}/pw-ph-wann/nscf/')
+#     softlink = '../scf/tmp'
+#     print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
+#     print(f'\n =Link tmp from scf= :\n {softlink}')
+#     sys.stdout.flush()
+#     os.symlink(softlink, 'tmp')
+#
+#     print(f' === Running nscf === :\n {run}')
+#     sys.stdout.flush()
+#
+#     subprocess.run(preliminary_commands(config_machine, 'nscf') + run, shell=True)
+#
+#     os.chdir(source_folder)
+#
+#
+# def run_wannier(source_folder, work_path, config_machine, prefix, input_name='pw2wan.in', output_name='pw2wan.out'):
+#     """
+#     Function for wannier90 calculation
+#
+#     Parameters
+#     ----------
+#     source_folder : str
+#         path of source directory
+#     work_path : str
+#         path to dir with input file, where we'll run the calculations
+#     config_machine : dict
+#         dictionary, which include the commands for wannier calculation
+#     prefix : str
+#         prefix which we use for the filenames
+#     input_name : str, optional
+#         name of the input file, default: 'pw2wan.in'
+#     output_name : str, optional
+#         name of the output file, default: 'pw2wan.out'
+#
+#     Returns
+#     -------
+#     None
+#
+#     """
+#
+#     command = run_from_config_machine(config_machine, 'wannier90')
+#     run = f'{command} -pp {prefix}'
+#
+#     # link the save-file from scf calculation
+#     os.chdir(f'{work_path}/pw-ph-wann/wann/')
+#     os.mkdir('tmp')
+#     softlink = f'../../scf/tmp/{prefix}.save'
+#     print(f'\n ====== Path ======= :\n {os.getcwd()}\n')
+#     print(f'\n =Link tmp from scf= :\n {softlink}')
+#     sys.stdout.flush()
+#     os.symlink(softlink, f'tmp/{prefix}.save')
+#
+#     # first run of wannier90
+#     print(f' === Running pp === :\n {run}')
+#     sys.stdout.flush()
+#     subprocess.run(preliminary_commands(config_machine, 'wannier90') + run, shell=True)
+#
+#     # run of pw2wan
+#     command = run_from_config_machine(config_machine, 'pw2wannier90')
+#     run = f'{command} -i {input_name} | tee {output_name}'
+#     print(f' = Running pw2wan = :\n {run}')
+#     sys.stdout.flush()
+#     subprocess.run(preliminary_commands(config_machine, 'pw2wannier90') + run, shell=True)
+#
+#     # second run of wannier90
+#     command = run_from_config_machine(config_machine, 'wannier90')
+#     run = f'{command} {prefix}'
+#     print(f' = Running Wannier= :\n {run}')
+#     sys.stdout.flush()
+#     subprocess.run(preliminary_commands(config_machine, 'wannier90') + run, shell=True)
+#
+#     os.chdir(source_folder)
+#
 
 def run_qe2pert(source_folder, work_path, config_machine, prefix, input_name='qe2pert.in', output_name='qe2pert.out'):
     """
@@ -398,6 +399,7 @@ def get_test_materials(test_name, test_case, config_machine, source_folder):
             igns_n_tols)
 
 
+# Legacy code, it may be possible to use it again in the future, so don't delete it yet.
 # def run_epr_calculation(epr_name, config_machine, source_folder):
 #     """
 #     Run one test:
@@ -490,8 +492,9 @@ def run_epr_calculation(epr_name, config_machine, source_folder):
     # define the prefix - we'll need to have it in the later computations
     prefix = input_yaml[epr_name]['prefix']
 
-    # run scf
-    load_files_from_box(f'{config_machine["source_link"]}/{epr_name}',work_path)
+    # move supplementary files for this calculation
+    move_qe2pert_files(source_folder, work_path, epr_name, config_machine)
+    
 
     # run qe2pert
     run_qe2pert(source_folder, work_path, config_machine, prefix)

--- a/src/perturbopy/testing_code/test_functions.py
+++ b/src/perturbopy/testing_code/test_functions.py
@@ -77,24 +77,24 @@ def test_qe2pert(test_name, run_qe2pert, config_machine, source_folder):
     assert True
     
 
-# @pytest.mark.order(after="test_qe2pert")
-# def test_perturbo_for_qe2pert(test_name, run_qe2pert, config_machine, keep_perturbo, source_folder):
-#     """
-#     Second driver to run the tests for the perturbo.x executable.
-#     We call it only in the case if we call test_qe2pert as well
-#
-#     Parameters
-#     -----
-#     test_name : str
-#         name of the folder inside the tests/ folder
-#     run_qe2pert : str
-#         do we run qe2pert testing or not
-#     source_folder : str
-#         name of the folder, where should be all the testing supplementary files (reference, input files, etc.)
-#     Returns
-#     -----
-#     None
-#     """
-#     if not run_qe2pert:
-#         pytest.skip("Skipping by default, pass the --run_qe2pert arg in the command line for this test")
-#     test_perturbo(test_name, config_machine, keep_perturbo, source_folder, test_case='perturbo_for_qe2pert')
+@pytest.mark.order(after="test_qe2pert")
+def test_perturbo_for_qe2pert(test_name, run_qe2pert, config_machine, keep_perturbo, source_folder):
+    """
+    Second driver to run the tests for the perturbo.x executable.
+    We call it only in the case if we call test_qe2pert as well
+
+    Parameters
+    -----
+    test_name : str
+        name of the folder inside the tests/ folder
+    run_qe2pert : str
+        do we run qe2pert testing or not
+    source_folder : str
+        name of the folder, where should be all the testing supplementary files (reference, input files, etc.)
+    Returns
+    -----
+    None
+    """
+    if not run_qe2pert:
+        pytest.skip("Skipping by default, pass the --run_qe2pert arg in the command line for this test")
+    test_perturbo(test_name, config_machine, keep_perturbo, source_folder, test_case='perturbo_for_qe2pert')

--- a/src/perturbopy/testing_code/test_functions.py
+++ b/src/perturbopy/testing_code/test_functions.py
@@ -77,24 +77,24 @@ def test_qe2pert(test_name, run_qe2pert, config_machine, source_folder):
     assert True
     
 
-@pytest.mark.order(after="test_qe2pert")
-def test_perturbo_for_qe2pert(test_name, run_qe2pert, config_machine, keep_perturbo, source_folder):
-    """
-    Second driver to run the tests for the perturbo.x executable.
-    We call it only in the case if we call test_qe2pert as well
-
-    Parameters
-    -----
-    test_name : str
-        name of the folder inside the tests/ folder
-    run_qe2pert : str
-        do we run qe2pert testing or not
-    source_folder : str
-        name of the folder, where should be all the testing supplementary files (reference, input files, etc.)
-    Returns
-    -----
-    None
-    """
-    if not run_qe2pert:
-        pytest.skip("Skipping by default, pass the --run_qe2pert arg in the command line for this test")
-    test_perturbo(test_name, config_machine, keep_perturbo, source_folder, test_case='perturbo_for_qe2pert')
+# @pytest.mark.order(after="test_qe2pert")
+# def test_perturbo_for_qe2pert(test_name, run_qe2pert, config_machine, keep_perturbo, source_folder):
+#     """
+#     Second driver to run the tests for the perturbo.x executable.
+#     We call it only in the case if we call test_qe2pert as well
+#
+#     Parameters
+#     -----
+#     test_name : str
+#         name of the folder inside the tests/ folder
+#     run_qe2pert : str
+#         do we run qe2pert testing or not
+#     source_folder : str
+#         name of the folder, where should be all the testing supplementary files (reference, input files, etc.)
+#     Returns
+#     -----
+#     None
+#     """
+#     if not run_qe2pert:
+#         pytest.skip("Skipping by default, pass the --run_qe2pert arg in the command line for this test")
+#     test_perturbo(test_name, config_machine, keep_perturbo, source_folder, test_case='perturbo_for_qe2pert')


### PR DESCRIPTION
Hi everyone!!!
In this PR we are completely changing the test approach for `qe2pert.x`. In the original version, in order to compute epr files, we did a full computation starting from **SCF**. This allowed us not to waste memory storing heavy files, some of which are binary. 
However, this approach has 2 significant disadvantages:
1. Test time. On turbo all testing took _20 minutes_, in case of running tests in docker containers it took _several hours_.
2. Too high variation of results. Either because of the specific compilation of QE, or because of the fact that our calculations are quite simple and inaccurate initially, we often received epr files that _differed significantly_ from the original ones, even if `qe2pert.x` was working correctly. This did not allow us to test this executable file normally. 
Therefore, it was decided to use the following approach:
1. store all files needed for `qe2pert.x` calculations in **remote storage** (Box);
2. **Load them automatically** when `qe2pert.x` tests are run.
Thanks to the answer from https://lists.quantum-espresso.org/pipermail/users/2024-August/051827.html, we learned that binaries are not a problem when switching between GNU and Intel, so for each epr file we just have a folder inside the archive. The archive itself weighs 412 MB, which is not so critical. The archive is stored in our group's Caltech Box, and the file is accessible to everyone, but I don't think that's a problem.  At the same time, the time of tests on turbo was reduced to _3 minutes_, in docker containers it became less than _5 minutes_, and the problem with stability of calculations seems to have disappeared.

I'll be glad to receive any suggestions regarding the code and ideas on how to improve it! 