### PR TITLE
Fix link error for perturbo.x test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     
 setup(
     name='perturbopy',
-    version='0.6.0',
+    version='0.6.1',
     description="Suite of Python scripts for Perturbo testing and postprocessing",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/perturbopy/conftest.py
+++ b/src/perturbopy/conftest.py
@@ -117,7 +117,8 @@ def pytest_generate_tests(metafunc):
             )
         elif (metafunc.function.__name__ == 'test_qe2pert'):
             # download the necessary files from remote storage
-            load_files_from_box(source_folder, metafunc.config.getoption('config_machine'))
+            if metafunc.config.getoption('run_qe2pert'):
+                load_files_from_box(source_folder, metafunc.config.getoption('config_machine'))
             test_list = filter_tests(
                 all_test_list,
                 metafunc.config.getoption('epr_tags'),


### PR DESCRIPTION
Hi all, 
This PR fix minor error. In the previous version of the code, the `source_link` variable should have been specified in `config_machine.yml` always - even if `qe2pert` tests were not running. Now this argument is required only if `--run_qe2pert` option is passed.