### PR TITLE
Add functionality for the gpu testing

### DIFF
--- a/src/perturbopy/conftest.py
+++ b/src/perturbopy/conftest.py
@@ -107,10 +107,10 @@ def pytest_generate_tests(metafunc):
         # Get the list of all test folders
         all_test_list, all_dev_test_list = get_all_tests(metafunc.function.__name__, source_folder)
         
-        if metafunc.config.getoption('arch')!='gpu' and metafunc.config.getoption('arch')!='cpu':
+        if metafunc.config.getoption('arch') != 'gpu' and metafunc.config.getoption('arch') != 'cpu':
             raise KeyError("The architecture type must be 'cpu' or 'gpu'")
         
-        if metafunc.config.getoption('arch')=='gpu' and metafunc.config.getoption('run_qe2pert'):
+        if metafunc.config.getoption('arch') == 'gpu' and metafunc.config.getoption('run_qe2pert'):
             raise NotImplementedError("At the moment, the qe2pert implementation is not adapted for gpu, so running tests for it is not possible for "
                                       "this architecture.")
 

--- a/src/perturbopy/conftest.py
+++ b/src/perturbopy/conftest.py
@@ -66,6 +66,10 @@ def pytest_addoption(parser):
                      help='Save all epr-files from the qe2pert testing',
                      action='store_true')
                      
+    parser.addoption('--arch',
+                     help='type of architecture on which the tests are run - cpu or gpu',
+                     nargs="?", default='cpu')
+                     
     parser.addoption('--keep_preliminary',
                      help='Save all preliminary files for epr files calculations',
                      action='store_true')
@@ -102,6 +106,13 @@ def pytest_generate_tests(metafunc):
 
         # Get the list of all test folders
         all_test_list, all_dev_test_list = get_all_tests(metafunc.function.__name__, source_folder)
+        
+        if metafunc.config.getoption('arch')!='gpu' and metafunc.config.getoption('arch')!='cpu':
+            raise KeyError("The architecture type must be 'cpu' or 'gpu'")
+        
+        if metafunc.config.getoption('arch')=='gpu' and metafunc.config.getoption('run_qe2pert'):
+            raise NotImplementedError("At the moment, the qe2pert implementation is not adapted for gpu, so running tests for it is not possible for "
+                                      "this architecture.")
 
         if (metafunc.function.__name__ == 'test_perturbo') or (metafunc.function.__name__ == 'test_perturbo_for_qe2pert'):
             # sort out test folders based on command-line options (if present)
@@ -113,6 +124,7 @@ def pytest_generate_tests(metafunc):
                 metafunc.config.getoption('test_names'),
                 metafunc.function.__name__,
                 metafunc.config.getoption('run_qe2pert'),
+                metafunc.config.getoption('arch'),
                 source_folder
             )
         elif (metafunc.function.__name__ == 'test_qe2pert'):
@@ -127,6 +139,7 @@ def pytest_generate_tests(metafunc):
                 None,
                 metafunc.function.__name__,
                 metafunc.config.getoption('run_qe2pert'),
+                metafunc.config.getoption('arch'),
                 source_folder
             )
         

--- a/src/perturbopy/test_utils/run_test/run_utils.py
+++ b/src/perturbopy/test_utils/run_test/run_utils.py
@@ -127,7 +127,7 @@ def print_test_info(test_name, input_dict, test_type):
     sys.stdout.flush()
 
 
-def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, run_qe2pert, source_folder):
+def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, run_qe2pert, arch, source_folder):
     """
     Return the list of test folders based on command line options
 
@@ -154,6 +154,9 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
     
     run_qe2pert : bool
         whether perturbo_for_qe2pert tests are conducted or not
+    
+    arch : str
+        type of architecture on which the tests are run - cpu or gpu
 
     source_folder : str
         name of the folder, where should be all the testing supplementary files (reference, input files, etc.)
@@ -174,9 +177,16 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
        if --test-names contains a name of a test that is not present
     """
     test_list = copy.deepcopy(all_test_list)
+    test_tag_dict, epr_names = read_test_tags(func_name, source_folder)
+    
+    # sort based on architecture
+    if func_name=='test_perturbo':
+        for test_name in all_test_list:
+            if arch not in test_tag_dict[test_name]:
+                test_list.remove(test_name)
+
     # sort based on tags
     if tags is not None or exclude_tags is not None or epr is not None:
-        test_tag_dict, epr_names = read_test_tags(func_name, source_folder)
         for test_name in all_test_list:
             if tags is not None:
                 

--- a/src/perturbopy/test_utils/run_test/run_utils.py
+++ b/src/perturbopy/test_utils/run_test/run_utils.py
@@ -180,7 +180,7 @@ def filter_tests(all_test_list, tags, exclude_tags, epr, test_names, func_name, 
     test_tag_dict, epr_names = read_test_tags(func_name, source_folder)
     
     # sort based on architecture
-    if func_name=='test_perturbo':
+    if func_name == 'test_perturbo':
         for test_name in all_test_list:
             if arch not in test_tag_dict[test_name]:
                 test_list.remove(test_name)


### PR DESCRIPTION
Hello everyone, 
In this PR, we add functionality for testing gpu-version of Perturbo.
Main changes:

1. Additional command line `--arch` (by default equal to `cpu`). Characterize the type of architecture that user want to check;
2. After this PR, in the `test_listing.yml` you should have architecture as a tag of the test, otherwise it will be ignored;
3. Choice of the test by the argument `arch` is going on the step of filtering, along with the filtering by tags and names.

Let me know what do you think!