### PR TITLE
Simplify attribute names for imsigma_spin calc mode and fix typo

### DIFF
--- a/src/perturbopy/postproc/calc_modes/imsigma_spin.py
+++ b/src/perturbopy/postproc/calc_modes/imsigma_spin.py
@@ -28,12 +28,12 @@ class ImsigmaSpin(CalcMode):
         give the configuration number, and the values are floats giving the
         chemical potential (with units chem_pot.units)
     
-    imsigma_flip : UnitsDict
+    imsigma : UnitsDict
         Dictionary of spin flip imaginary self-energies computed for each configuration. The top level keys are the
         configuration number, and the second level keys are the band index. The values are arrays of length N giving the
         imaginary self-energies along all the k-points at that band index for the configuration. Units are in imsigma.units.
 
-    imsigma_flip_mode : UnitsDict
+    imsigma_mode : UnitsDict
         Dictionary of spin flip imaginary self-energies resolved by phonon mode computed. The top level keys are the
         configuration number, and the second level keys are the band index. The third level keys are
         the phonon mode. Finally,the values are arrays of length N giving the imaginary self-energies along all the k-points
@@ -72,22 +72,22 @@ class ImsigmaSpin(CalcMode):
 
         self.temper = UnitsDict(units=self._pert_dict['imsigma_spin'].pop('temperature units'))
         self.chem_pot = UnitsDict(units=self._pert_dict['imsigma_spin'].pop('chemical potential units'))
-        self.imsigma_flip = UnitsDict(units=self._pert_dict['imsigma_spin'].pop('Im(Sigma) units'))
-        self.imsigma_flip_mode = UnitsDict(units=self.imsigma_flip.units)
+        self.imsigma = UnitsDict(units=self._pert_dict['imsigma_spin'].pop('Im(Sigma) units'))
+        self.imsigma_mode = UnitsDict(units=self.imsigma.units)
         
         for config_idx in config_dat.keys():
-            self.imsigma_flip[config_idx] = {}
-            self.imsigma_flip_mode[config_idx] = {}
+            self.imsigma[config_idx] = {}
+            self.imsigma_mode[config_idx] = {}
             self.temper[config_idx] = config_dat[config_idx].pop('temperature')
             self.chem_pot[config_idx] = config_dat[config_idx].pop('chemical potential')
             
             imsigma_dat = config_dat[config_idx].pop('band index')
 
             for mode in np.arange(1, num_modes + 1):
-                self.imsigma_flip_mode[config_idx][mode] = {}
+                self.imsigma_mode[config_idx][mode] = {}
 
             for band_index in imsigma_dat.keys():
-                self.imsigma_flip[config_idx][band_index] = np.array(imsigma_dat[band_index]['Im(Sigma)']['total'])
+                self.imsigma[config_idx][band_index] = np.array(imsigma_dat[band_index]['Im(Sigma)']['total'])
 
                 for mode in np.arange(1, num_modes + 1):
-                    self.imsigma_flip_mode[config_idx][mode][band_index] = np.array(imsigma_dat[band_index]['Im(Sigma)']['phonon mode (total)'][mode])
+                    self.imsigma_mode[config_idx][mode][band_index] = np.array(imsigma_dat[band_index]['Im(Sigma)']['phonon mode (total)'][mode])

--- a/src/perturbopy/postproc/calc_modes/spins.py
+++ b/src/perturbopy/postproc/calc_modes/spins.py
@@ -81,7 +81,7 @@ class Spins(CalcMode):
 
         values = {key: 1 - val for key, val in self.spins.items()}
 
-        ax = plot_vals_on_bands(ax, self.kpt.path, self.bands, self.bands.units, values=values, log=log, label=r'$|\langle n | \sigma_z | n \rangle |$', **kwargs)
+        ax = plot_vals_on_bands(ax, self.kpt.path, self.bands, self.bands.units, values=values, log=log, label=r'$|\langle n|\sigma_z|n\rangle |$', **kwargs)
 
         if show_kpoint_labels:
             ax = plot_recip_pt_labels(ax, self.kpt.labels, self.kpt.points, self.kpt.path)

--- a/src/perturbopy/postproc/calc_modes/spins.py
+++ b/src/perturbopy/postproc/calc_modes/spins.py
@@ -45,7 +45,7 @@ class Spins(CalcMode):
         energy_units = self._pert_dict['spins'].pop('band units')
 
         spins_dict = self._pert_dict['spins'].pop('band index (spins)')
-        spin_units = self._pert_dict['spins'].pop('<n|Sigma_z|n> units')
+        spin_units = self._pert_dict['spins'].pop('<n|sigma_z|n> units')
 
         self.kpt = RecipPtDB.from_lattice(kpoint, kpoint_units, self.lat, self.recip_lat, kpath, kpath_units)
         self.bands = UnitsDict.from_dict(energies_dict, energy_units)
@@ -53,7 +53,7 @@ class Spins(CalcMode):
 
     def plot_spins(self, ax, kpoint_idx=0, show_kpoint_labels=True, log=True, **kwargs):
         """
-        Method to plot the <n|Sigma_z|n> values over the band structure.
+        Method to plot the <n|sigma_z|n> values over the band structure.
 
         Parameters
         ----------
@@ -61,7 +61,7 @@ class Spins(CalcMode):
            Axis on which to plot the bands.
         
         kpoint_idx : int, optional
-           Index of the k-point to plot the <n|Sigma_z|n> values for. <n|Sigma_z|n> elements will be plotted along k-points, at this k-point
+           Index of the k-point to plot the <n|sigma_z|n> values for. <n|sigma_z|n> elements will be plotted along k-points, at this k-point
            By default, it will be the first k-point.
 
         show_kpoint_labels : bool, optional
@@ -81,7 +81,7 @@ class Spins(CalcMode):
 
         values = {key: 1 - val for key, val in self.spins.items()}
 
-        ax = plot_vals_on_bands(ax, self.kpt.path, self.bands, self.bands.units, values=values, log=log, label=r'$|<n|\Sigma_z|n>|$', **kwargs)
+        ax = plot_vals_on_bands(ax, self.kpt.path, self.bands, self.bands.units, values=values, log=log, label=r'$|\langle n | \sigma_z | n \rangle |$', **kwargs)
 
         if show_kpoint_labels:
             ax = plot_recip_pt_labels(ax, self.kpt.labels, self.kpt.points, self.kpt.path)

--- a/tests/refs/gaas_spins.yml
+++ b/tests/refs/gaas_spins.yml
@@ -2163,7 +2163,7 @@ spins:
          -   13.0429498274
          -   13.0081597319
 
-   <n|Sigma_z|n> units: arbitrary
+   <n|sigma_z|n> units: arbitrary
    band index (spins):
 
       1:


### PR DESCRIPTION
Hello,

This PR is a small change to simplify the attribute names for the imsigma_spin calc mode. Since the output format is identical to the imsigma calc mode, now the attribute names are the same - the only difference is the class name. I think this will make accessing the data much simpler.

Also I made a typo (Sigma_z vs sigma_z) when generating the spins yaml file, so I corrected the spins calc mode script accordingly. I also changed the reference file used in the testsuite.