### PR TITLE
Switch from usage of the supplementary test program to entry point

### DIFF
--- a/docs/source/testsuite.rst
+++ b/docs/source/testsuite.rst
@@ -71,13 +71,13 @@ Once, the ``config_machine.yml`` is set up, navigate to the `tests` folder and r
 
 .. code-block:: console
 
-	(perturbopy) $ ./run_tests.py
+	(perturbopy) $ run-tests
    
-This script will automatically load and run all the tests from the `perturbopy` package.
+This command will automatically load and run all the tests from the `perturbopy` package.
 
 By default, in the case of successful run of all tests one will see **<n> passed** as the final line of the output, where <n> is the number of tests. You will also see that some tests have been skipped. This is fine, because the tests for ``qe2pert.x`` are skipped if it's not specified.
 
-If all tests are passed, the `PERT_SCRATCH/perturbo` directory will be empty after the ``./run_tests.py`` execution. In the case of a failure of one or more tests, the corresponding test folder(s) kept in the ``PERT_SCRATH/perturbo`` directory.
+If all tests are passed, the `PERT_SCRATCH/perturbo` directory will be empty after the ``run-tests`` command execution. In the case of a failure of one or more tests, the corresponding test folder(s) kept in the ``PERT_SCRATH/perturbo`` directory.
 
 .. _test-complete:
 
@@ -99,7 +99,7 @@ To enable the tests of ``qe2pert.x``, activate the ``--run_qe2pert`` option:
 
 .. code-block:: console
 
-	(perturbopy) $ ./run_tests.py --run_qe2pert
+	(perturbopy) $ run-tests --run_qe2pert
 
 Similarly to ``perturbo.x``-only tests, the user needs to make a new the *config_machine/config_machine.yml* file, but this time the file should include more information. As a reference, you can take file  *config_machine_qe2pert.yaml*.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -22,7 +22,20 @@ Here is an example to create and activate this environment with `anaconda`:
 Installation
 ------------
 
-To use perturbopy, first clone it from the GitHub repository:
+To use perturbopy, you can chose on the following ways: 
+
+1. From PyPI (default option)
+
+You can install perturbopy from PyPI using pip:
+
+.. code-block:: console
+
+   (perturbopy) $ pip install perturbopy
+
+
+2. From the source code
+
+First clone it from the GitHub repository:
 
 .. code-block:: console
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,10 @@ interactive = [
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["perturbopy"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [project.scripts]
 input_generation = "perturbopy.generate_input:input_generation"
+run-tests = "perturbopy.tests_use:main"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     entry_points={
         'console_scripts': [
             'input_generation=perturbopy.generate_input:input_generation',
+            'run-tests=perturbopy.tests_use:main',
         ],
     },
 )

--- a/src/perturbopy/tests_use.py
+++ b/src/perturbopy/tests_use.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import sys
 from perturbopy import testing_code
 
 
@@ -8,3 +9,8 @@ def do_tests(testing_args):
     testing_args.insert(0, dir_path)
     result = pytest.main(testing_args)
     return result
+
+
+def main():
+    result = do_tests(sys.argv[1:])
+    sys.exit(result)


### PR DESCRIPTION
Hello everyone, 
In this PR, I solve the issue of the supplementary program for tests running.
Previously, in the perturbo repo we needed to have additional code `run_tests.py`. Now, we just have entry point - terminal command, as in case of the input generation

Additionally, in this package I update pyproject.toml, because I found bug in the way how pip looking for the subfolders