### PR TITLE
Automated pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,10 @@ interactive = [
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["perturbopy"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [project.scripts]
 input_generation = "perturbopy.generate_input:input_generation"
+auto_pipeline = "perturbopy.auto_pipeline.auto_pipeline:run_epr_calculation"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     entry_points={
         'console_scripts': [
             'input_generation=perturbopy.generate_input:input_generation',
+            'auto_pipeline = perturbopy.auto_pipeline.auto_pipeline:run_epr_calculation',
         ],
     },
 )

--- a/src/perturbopy/auto_pipeline/__init__.py
+++ b/src/perturbopy/auto_pipeline/__init__.py
@@ -1,0 +1,1 @@
+"The automated pipeline for the preliminary QE steps and qe2pert.x calculations."

--- a/src/perturbopy/auto_pipeline/ap_utils.py
+++ b/src/perturbopy/auto_pipeline/ap_utils.py
@@ -1,0 +1,90 @@
+import os
+import shutil
+
+
+def make_computational_folder(perturbo_inputs_dir_path, config_machine, rm_preexist_dir=True):
+    """
+    Check if the COMP_FOLD variable is written in the config_machine file.
+    If not - use default location "/COMP_FOLD".
+    After it, this programm make the copy from folder with input files from inputs folder.
+    
+
+    Parameters
+    ----------
+    source_folder : str
+        path of source directory
+
+    perturbo_inputs_dir_path : str
+        folder with all input files for the test
+
+    config_machine : dict
+        dictionary with computational information, which we'll use in this set of computations.
+
+    rm_preexist_dir : bool
+        whether to remove dir if it preexists
+
+    Returns
+    -------
+    comp_folder : str
+        string containing the path to generate directory in which
+        outputs for computation will be generated
+
+    """
+    # Read the perturbo_run variable from the environment
+    perturbo_folder_dir_prefix   = "COMP_FOLD"
+    try:
+        perturbo_folder_dir_prefix = config_machine['COMP_FOLD']
+    except KeyError:
+        print(f'COMP_FOLD not set in the config_machine. using default location -  {perturbo_folder_dir_prefix}')
+
+    # if folder already exist and we don't want to change it - simply pass rest of the function
+    perturbo_folder_dir = perturbo_folder_dir_prefix
+    if not rm_preexist_dir:
+        return perturbo_folder_dir
+
+    # else - copy over input files to scratch dir
+    src = perturbo_inputs_dir_path
+    dst = perturbo_folder_dir
+    if os.path.isdir(dst):
+        print(f'\n directory {dst} exists. Removing this directory ...\n')
+        shutil.rmtree(dst)
+        copy_folder_with_softlinks(src, dst)
+    else:
+        copy_folder_with_softlinks(src, dst)
+
+    return os.path.abspath(perturbo_folder_dir)
+
+
+def copy_folder_with_softlinks(src, dst):
+    """
+    Copy the src directory to the dst directory.
+
+    Parameters
+    ----------
+    src : str
+        folder with computational info, which is copied
+    
+    dst : str
+        folder, where the files will be copied
+
+    Returns
+    -------
+    None
+    """
+    os.makedirs(dst)
+
+    # Get the list of files in the source folder
+    for root, dirs, files in os.walk(src):
+        
+        # Determine the relative path of the current directory
+        relative_path = os.path.relpath(root, src)
+        
+        # Create the corresponding subdirectory in the destination folder
+        dst_subfolder = os.path.join(dst, relative_path)
+        if not os.path.exists(dst_subfolder):
+            os.makedirs(dst_subfolder)
+
+        for file_name in files:
+            src_file_path = os.path.join(root, file_name)
+            dst_file_path = os.path.join(dst_subfolder, file_name)
+            shutil.copy2(src_file_path, dst_file_path)

--- a/src/perturbopy/auto_pipeline/auto_pipeline.py
+++ b/src/perturbopy/auto_pipeline/auto_pipeline.py
@@ -263,18 +263,14 @@ def run_qe2pert(source_folder, work_path, config_machine, prefix, input_name='qe
     os.symlink(softlink, f'tmp/{prefix}.save')
     
     # link rest files
-    softlink = f'../pw-ph-wann/wann/{prefix}_u.mat'
     print(f'\n = Link rest files = :\n {softlink};')
     sys.stdout.flush()
-    os.symlink(softlink, f'{prefix}_u.mat')
-    softlink = f'../pw-ph-wann/wann/{prefix}_u_dis.mat'
-    print(f'\n {softlink};')
-    sys.stdout.flush()
-    os.symlink(softlink, f'{prefix}_u_dis.mat')
-    softlink = f'../pw-ph-wann/wann/{prefix}_centres.xyz'
-    print(f'\n {softlink};')
-    sys.stdout.flush()
-    os.symlink(softlink, f'{prefix}_centres.xyz')
+    for file in os.listdir(f'{work_path}/pw-ph-wann/wann/'):
+        if file.startswith(prefix):
+            softlink = f'../pw-ph-wann/wann/{file}'
+            print(f'\n {softlink};')
+            sys.stdout.flush()
+            os.symlink(softlink, file)
 
     # run qe2pert
     print(f' = Running qe2pert = :\n {run}')


### PR DESCRIPTION
Hello everyone, 
In this PR, I am adding an automated pipeline for calculations using QE and Perturbo. The idea is to create in advance a folder with input files and a config file to run the calculation correctly. Then all intermediate operations (sequential launching of calculations, creating folders, transferring and creating links to files/folders) are done automatically.
PR is in draft version for now, because I would like to extend the presented functionality. Ideally, I would like to be able to change some calculations parameters (grid, pseudopotentials, etc) directly from pipeline. In addition, I would like you to test its usability.

To run the pipeline, you need a folder similar to the test folder (epr1 for example). Inside, you should have the pw-ph-wann and qe2pert folders, and a config-machine folder with the config_machine.yml file. Its structure looks like this:
COMP_FOLD: results
prefix: gaas
comp_info:
    scf:
        exec: pw.x
    nscf:
        exec: pw.x
    phonon:
        exec: ph.x
    wannier90:
        exec: wannier90.x
    pw2wannier90:
        exec: pw2wannier90.x
    qe2pert:
        prel_coms:
            - export OMP_NUM_THREADS=8
        exec: qe2pert.x

further launch is carried out with the help of entry point command:


auto_pipeline --source_folder epr1

Let me know what do you think about this PR!